### PR TITLE
Fix log download for partial logs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
-email = "logs@arkelectron.com"
+email = "you@example.com"
 server = "review.px4.io"
 connection_url = "udp://:14551"
-upload_enabled = true
+upload_enabled = false
 public_logs = false

--- a/src/LogLoader.cpp
+++ b/src/LogLoader.cpp
@@ -108,7 +108,7 @@ void LogLoader::run()
 		// If we have no logs, just download the latest
 		auto most_recent_log = find_most_recent_log();
 
-		if (most_recent_log.size_bytes == 0) {
+		if (most_recent_log.date.empty()) {
 			download_first_log();
 
 		} else {
@@ -165,9 +165,10 @@ void LogLoader::download_logs_greater_than(const mavsdk::LogFiles::Entry& most_r
 				std::cout << "Incomplete log, re-downloading..." << std::endl;
 				std::cout << "size actual/downloaded: " << entry.size_bytes << "/" << most_recent.size_bytes << std::endl;
 
-				// If the timestamps are the same then the logfile already exists and we must remove it first
-				if (entry.date == most_recent.date) {
-					fs::remove(filepath_from_entry(entry));
+				auto log_path = filepath_from_entry(entry);
+
+				if (fs::exists(log_path)) {
+					fs::remove(log_path);
 				}
 			}
 

--- a/src/LogLoader.cpp
+++ b/src/LogLoader.cpp
@@ -341,7 +341,9 @@ void LogLoader::mark_log_as_uploaded(const std::string& file_path)
 
 std::string LogLoader::filepath_from_entry(const mavsdk::LogFiles::Entry entry)
 {
-	return _settings.logging_directory + "LOG" + std::to_string(entry.id) + "_" + entry.date + ".ulg";
+	std::ostringstream ss;
+	ss << _settings.logging_directory << "LOG" << std::setfill('0') << std::setw(4) << entry.id << "_" << entry.date << ".ulg";
+	return ss.str();
 }
 
 bool LogLoader::server_reachable()

--- a/src/LogLoader.cpp
+++ b/src/LogLoader.cpp
@@ -222,6 +222,8 @@ bool LogLoader::download_log(const mavsdk::LogFiles::Entry& entry)
 			  << std::flush << std::endl;
 
 		if (result != mavsdk::LogFiles::Result::Next) {
+			double seconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - time_start).count() / 1000.;
+			std::cout << "Finished in " << std::setprecision(2) << seconds << " seconds" << std::endl;
 			prom.set_value(result);
 		}
 	});

--- a/src/LogLoader.cpp
+++ b/src/LogLoader.cpp
@@ -108,8 +108,6 @@ void LogLoader::run()
 		// If we have no logs, just download the latest
 		auto most_recent_log = find_most_recent_log();
 
-		std::cout << "most_recent: id " << most_recent_log.id << " size " << most_recent_log.size_bytes << std::endl;
-
 		if (most_recent_log.size_bytes == 0) {
 			download_first_log();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,6 @@ int main()
 	toml::table config;
 
 	try {
-
 		config = toml::parse_file(std::string(getenv("HOME")) + "/.local/share/logloader/config.toml");
 
 	} catch (const toml::parse_error& err) {


### PR DESCRIPTION
- Changed format to LOGnnnn_* such that there are always at least 4 digits in the log number
- default upload disabled
- fixed check for non existant most_recent file
- fixed check for latest log to include ID and datetime (solves issue redownloading partial logs)