### PR TITLE
Sys status for logging detection and remove erreonous zero length files

### DIFF
--- a/src/LogLoader.hpp
+++ b/src/LogLoader.hpp
@@ -55,8 +55,10 @@ private:
 	std::pair<std::string, bool> _current_download {};
 
 	std::atomic<bool> _should_exit = false;
-	std::atomic<bool> _exiting = false;
+	std::atomic<bool> _download_cancelled = false;
 
 	std::condition_variable _exit_cv;
 	std::mutex _exit_cv_mutex;
+
+	bool _loop_disabled = false;
 };


### PR DESCRIPTION
- Pending PR to query SysStatus flags to detect when the logger is running. Handles case where logger is running while drone is disarmed https://github.com/mavlink/MAVSDK/pull/2383

- In some cases a log with zero length can be created if the user kills the program before a download starts. Added logic in the **upload_logs_thread** function to remove zero length log files since the server will throw an error and we end up in an infinite loop.