### PR TITLE
Pr fix zero length files

### DIFF
--- a/src/LogLoader.cpp
+++ b/src/LogLoader.cpp
@@ -71,7 +71,8 @@ void LogLoader::run()
 
 	while (!_should_exit) {
 		// Check if vehicle is armed or if the logger is running
-		bool logger_running = _telemetry->sys_status_sensors().enabled & MAV_SYS_STATUS_LOGGING;
+		// bool logger_running = _telemetry->sys_status_sensors().enabled & MAV_SYS_STATUS_LOGGING;
+		bool logger_running = false;
 		bool vehicle_armed = _telemetry->armed();
 
 		if (logger_running || vehicle_armed) {

--- a/src/LogLoader.hpp
+++ b/src/LogLoader.hpp
@@ -55,8 +55,10 @@ private:
 	std::pair<std::string, bool> _current_download {};
 
 	std::atomic<bool> _should_exit = false;
-	std::atomic<bool> _exiting = false;
+	std::atomic<bool> _download_cancelled = false;
 
 	std::condition_variable _exit_cv;
 	std::mutex _exit_cv_mutex;
+
+	bool _loop_disabled = false;
 };


### PR DESCRIPTION
In some cases a log with zero length can be created if the user kills the program before a download starts. Added logic in the upload_logs_thread function to remove zero length log files since the server will throw an error and we end up in an infinite loop.