### PR TITLE
feat(config): add --config flag with $HOME fallback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,22 +10,34 @@ static void signal_handler(int signum);
 std::atomic<bool> _should_exit = false;
 std::shared_ptr<LogLoader> _log_loader;
 
-int main()
+int main(int argc, char** argv)
 {
 	signal(SIGINT, signal_handler);
 	signal(SIGTERM, signal_handler);
 	setbuf(stdout, NULL); // Disable stdout buffering
 
-	// Two-tier config lookup: user override > deb-installed default
+	// Config lookup: --config <path> (or --config=<path>) overrides everything;
+	// otherwise user override > deb-installed default.
 	const std::string home = getenv("HOME") ? getenv("HOME") : "/tmp";
 	const auto user_config = std::filesystem::path(home) / ".config/ark/logloader/config.toml";
 	const auto default_config = std::filesystem::path("/opt/ark/share/logloader/config.toml");
-	const auto config_path = std::filesystem::exists(user_config) ? user_config : default_config;
+	std::string config_path = (std::filesystem::exists(user_config) ? user_config : default_config).string();
+
+	for (int i = 1; i < argc; i++) {
+		std::string arg = argv[i];
+
+		if (arg == "--config" && i + 1 < argc) {
+			config_path = argv[++i];
+
+		} else if (arg.rfind("--config=", 0) == 0) {
+			config_path = arg.substr(std::string("--config=").size());
+		}
+	}
 
 	toml::table config;
 
 	try {
-		config = toml::parse_file(config_path.string());
+		config = toml::parse_file(config_path);
 
 	} catch (const toml::parse_error& err) {
 		std::cerr << "Parsing failed:\n" << err << "\n";
@@ -46,7 +58,7 @@ int main()
 		.local_server = config["local_server"].value_or("http://127.0.0.1:5006"),
 		.remote_server = config["remote_server"].value_or("https://logs.px4.io"),
 		.mavsdk_connection_url = config["connection_url"].value_or("0.0.0"),
-		.application_directory = data_dir.string() + "/",
+		.application_directory = config["application_directory"].value_or(data_dir.string() + "/"),
 		.upload_enabled = config["upload_enabled"].value_or(false),
 		.public_logs = config["public_logs"].value_or(false)
 	};


### PR DESCRIPTION
## Summary

Add a `--config <path>` (or `--config=<path>`) argument so the config file can be read from an explicit path, and make the log-staging directory configurable, both defaulting to the existing `$HOME` locations.

## Problem

The config path and the ulog staging directory were hardcoded to `$HOME/.local/share/logloader/`. ARK-OS is moving to FHS packaging where the config lives at `/etc/ark-os/logloader.toml` and the service runs as a system user, so the binary, the web UI, and the shipped config must all reference the same path, and downloaded logs must land under `/var/lib/ark-os/logs`.

## Solution

Parse `--config`/`--config=` from argv and use it for the TOML load, keeping the `$HOME` path as the default so dev-machine behaviour is unchanged. The staging directory is now read from a new `application_directory` config key with the same `$HOME` fallback.

Part of ARK-Electronics/ARK-OS#68.
