### PR TITLE
feat(logloader): download logs over MAVLink FTP only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ include_directories(${SQLite3_INCLUDE_DIRS})
 add_executable(${PROJECT_NAME}
     src/main.cpp
     src/ServerInterface.cpp
+    src/FtpListClient.cpp
+    src/FtpLogFetcher.cpp
     src/LogLoader.cpp)
 
 target_link_libraries(${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,28 @@
 ![image](logloader_logo.png)
 
-Downloads PX4 log files (.ulg) and uploads them to a local server and optionally a remote server.
+Downloads flight logs from the vehicle and uploads them to a local server and optionally a remote server. Works with PX4 (`.ulg`) and ArduPilot (`.BIN`).
 
 The **config.toml** file is used to configure the program settings.
 
 ### Behavior
 Downloading and uploading will only occur while the vehicle is not armed. Downloading and uploading operations are performed in separate threads. An sqlite database per server is used to track log file download/upload status.
+
+### Log transport
+Everything runs over **MAVLink FTP** (`FILE_TRANSFER_PROTOCOL`, msg 110): the directory listing that finds the logs and the bulk transfer that downloads them. The classic log protocol (`LOG_REQUEST_LIST` / `LOG_ENTRY` / `LOG_DATA`, msgs 117-120) is not used at all.
+
+`FILE_TRANSFER_PROTOCOL` carries `target_system` and `target_component`, and both PX4 and ArduPilot address their replies back to the requesting sysid/compid, so a download is unicast between the vehicle and logloader. `LOG_DATA` has no target fields, which leaves a router in between — mavlink-router, for instance — no choice but to copy every chunk to every endpoint it serves, telemetry radio included. A log download over the old protocol saturates links that have no interest in it.
+
+The autopilot's MAVLink instance must have FTP enabled (`mavlink start -x` on PX4). If it does not, logloader says so and idles.
+
+### Log discovery
+At startup logloader lists the vehicle's log directory, trying `@MAV_LOG` first — the virtual log directory the MAVLink FTP specification defines, supported by PX4 v1.17 and newer — then the physical `/fs/microsd/log` (PX4) and `/APM/LOGS` (ArduPilot). Set `remote_log_directory` to skip the probe. The listing is what identifies a log: its path below the log root plus its size. PX4's nested `<date>/<time>.ulg` layout and ArduPilot's flat `<number>.BIN` layout are both handled, and the file extension follows whatever the vehicle actually has.
+
+Log timestamps come from the modification time in the listing when the vehicle supports the `ListDirectoryWithTime` opcode (PX4 v1.17 and newer). Otherwise PX4 logs fall back to the start time encoded in the path, and ArduPilot logs have no timestamp — nothing depends on having one.
+
+Downloads are staged in a temporary directory and only moved next to the finished logs once the transferred size matches the listing, so a partial file is never mistaken for a complete one.
+
+### Upgrading from a pre-FTP logloader
+Older versions identified logs by the timestamp `LOG_ENTRY` reported, which MAVLink FTP cannot reproduce. On first start the existing `logs` table is renamed to `logs_legacy` and its rows are matched against the FTP listing by size, so logs already downloaded and uploaded are not fetched or uploaded a second time. Nothing is deleted; `logs_legacy` stays behind for inspection.
 
 ### Build
 Install dependencies
@@ -85,7 +102,7 @@ sudo iftop -i wlo1
 ```
 Or use a Wireshark filter
 ```
-mavlink_proto.msgid == 117 || mavlink_proto.msgid == 118 || mavlink_proto.msgid == 119 || mavlink_proto.msgid == 120
+mavlink_proto.msgid == 110
 ```
 
 Watch your beautiful logs arrive

--- a/config.toml
+++ b/config.toml
@@ -4,3 +4,12 @@ remote_server = "https://review.px4.io"
 email = ""
 upload_enabled = false
 public_logs = false
+
+# Vehicle log directory. Empty probes "@MAV_LOG" (the virtual log directory from
+# the MAVLink FTP specification), then "/fs/microsd/log" (PX4) and "/APM/LOGS"
+# (ArduPilot). Set this when the logs live somewhere else.
+remote_log_directory = ""
+
+# FTP burst reads. Much faster, disable it if the flight stack's burst support
+# misbehaves.
+ftp_use_burst = true

--- a/src/FtpListClient.cpp
+++ b/src/FtpListClient.cpp
@@ -1,0 +1,251 @@
+#include "FtpListClient.hpp"
+#include "Log.hpp"
+
+#include <chrono>
+#include <cstring>
+
+namespace
+{
+
+constexpr int kMaxAttempts = 3;
+
+// Generous enough for a listing that has to come back over a telemetry link.
+// Servers answer a retransmitted request from their reply cache, so a retry
+// after a dropped packet is cheap.
+constexpr auto kReplyTimeout = std::chrono::milliseconds(2000);
+
+} // namespace
+
+FtpListClient::FtpListClient(std::shared_ptr<mavsdk::System> system)
+	: _passthrough(std::make_shared<mavsdk::MavlinkPassthrough>(system))
+{
+	_subscription = _passthrough->subscribe_message(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL,
+	[this](const mavlink_message_t& message) {
+		handle_message(message);
+	});
+}
+
+FtpListClient::~FtpListClient()
+{
+	_passthrough->unsubscribe_message(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, _subscription);
+}
+
+void FtpListClient::stop()
+{
+	_should_exit = true;
+	_cv.notify_all();
+}
+
+void FtpListClient::reset_sessions()
+{
+	PayloadHeader reply;
+
+	if (transact(kOpcodeResetSessions, "", 0, reply)) {
+		LOG_DEBUG("FTP sessions reset");
+
+	} else {
+		LOG_DEBUG("FTP session reset went unanswered");
+	}
+}
+
+void FtpListClient::handle_message(const mavlink_message_t& message)
+{
+	mavlink_file_transfer_protocol_t ftp;
+	mavlink_msg_file_transfer_protocol_decode(&message, &ftp);
+
+	// The transfer runs unicast: the server addresses its replies to whoever
+	// asked. Anything not for us is another client's traffic.
+	if (ftp.target_system != _passthrough->get_our_sysid()) {
+		return;
+	}
+
+	if (ftp.target_component != _passthrough->get_our_compid() && ftp.target_component != 0) {
+		return;
+	}
+
+	PayloadHeader payload;
+	std::memcpy(&payload, ftp.payload, sizeof(payload));
+
+	if (payload.opcode != kOpcodeAck && payload.opcode != kOpcodeNak) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> lock(_mutex);
+
+	// Match against the in-flight request so replies to MAVSDK's Ftp plugin
+	// (which shares our system and component id) are ignored.
+	if (!_expected_req_opcode.has_value() || payload.req_opcode != _expected_req_opcode.value()
+	    || payload.seq_number != _expected_seq) {
+		return;
+	}
+
+	_reply = payload;
+	_cv.notify_all();
+}
+
+void FtpListClient::send_request(const PayloadHeader& request)
+{
+	_passthrough->queue_message([this, request](MavlinkAddress address, uint8_t channel) {
+		mavlink_message_t message;
+		mavlink_msg_file_transfer_protocol_pack_chan(address.system_id, address.component_id, channel, &message,
+				0, // target_network
+				_passthrough->get_target_sysid(),
+				_passthrough->get_target_compid(),
+				reinterpret_cast<const uint8_t*>(&request));
+		return message;
+	});
+}
+
+bool FtpListClient::transact(uint8_t opcode, const std::string& path, uint32_t offset, PayloadHeader& reply)
+{
+	if (path.size() >= kMaxDataLength) {
+		return false;
+	}
+
+	PayloadHeader request {};
+	request.seq_number = ++_seq;
+	request.opcode = opcode;
+	request.offset = offset;
+	request.size = static_cast<uint8_t>(path.size() + 1);
+	std::memcpy(request.data, path.c_str(), path.size() + 1);
+
+	for (int attempt = 0; attempt < kMaxAttempts && !_should_exit; attempt++) {
+		{
+			std::lock_guard<std::mutex> lock(_mutex);
+			_reply.reset();
+			// Servers reply with the request sequence number plus one, and
+			// answer a retransmission (same sequence number) from their
+			// duplicate-reply cache, so retries reuse the packet as-is.
+			_expected_seq = static_cast<uint16_t>(request.seq_number + 1);
+			_expected_req_opcode = opcode;
+		}
+
+		send_request(request);
+
+		std::unique_lock<std::mutex> lock(_mutex);
+
+		if (_cv.wait_for(lock, kReplyTimeout, [this] { return _reply.has_value() || _should_exit.load(); })) {
+			_expected_req_opcode.reset();
+
+			if (_should_exit || !_reply.has_value()) {
+				return false;
+			}
+
+			reply = _reply.value();
+			return true;
+		}
+	}
+
+	std::lock_guard<std::mutex> lock(_mutex);
+	_expected_req_opcode.reset();
+
+	return false;
+}
+
+void FtpListClient::parse_entries(const PayloadHeader& reply, std::vector<Entry>& entries, uint32_t& next_offset)
+{
+	const size_t data_size = std::min(static_cast<size_t>(reply.size), kMaxDataLength);
+	size_t i = 0;
+
+	while (i < data_size) {
+		const char* raw = reinterpret_cast<const char*>(&reply.data[i]);
+		const size_t length = strnlen(raw, data_size - i);
+		i += length + 1;
+
+		// Every directory entry advances the server-side offset, including the
+		// "skip" placeholders it emits for entries it does not report.
+		next_offset++;
+
+		if (length < 2) {
+			continue;
+		}
+
+		const std::string body(raw + 1, length - 1);
+
+		if (raw[0] == 'D') {
+			Entry entry;
+			entry.name = body;
+			entry.is_directory = true;
+			entries.push_back(entry);
+
+		} else if (raw[0] == 'F') {
+			// "F<name>\t<size>" plus "\t<mtime>" from ListDirectoryWithTime
+			const size_t first_tab = body.find('\t');
+
+			if (first_tab == std::string::npos) {
+				continue;
+			}
+
+			Entry entry;
+			entry.name = body.substr(0, first_tab);
+
+			try {
+				const size_t second_tab = body.find('\t', first_tab + 1);
+				entry.size_bytes = static_cast<uint32_t>(std::stoul(body.substr(first_tab + 1)));
+
+				if (second_tab != std::string::npos) {
+					// The server reports zero when it does not know the time
+					const int64_t mtime = std::stoll(body.substr(second_tab + 1));
+
+					if (mtime > 0) {
+						entry.mtime_utc = mtime;
+					}
+				}
+
+			} catch (const std::exception&) {
+				continue;
+			}
+
+			entries.push_back(entry);
+		}
+	}
+}
+
+FtpListClient::Result FtpListClient::list_directory(const std::string& path, std::vector<Entry>& entries)
+{
+	entries.clear();
+
+	uint32_t offset = 0;
+
+	while (!_should_exit) {
+		const uint8_t opcode = _with_time_supported ? kOpcodeListDirectoryWithTime : kOpcodeListDirectory;
+
+		PayloadHeader reply;
+
+		if (!transact(opcode, path, offset, reply)) {
+			return _should_exit ? Result::Stopped : Result::Timeout;
+		}
+
+		if (reply.opcode == kOpcodeNak) {
+			const uint8_t error = reply.size > 0 ? reply.data[0] : 0;
+
+			if (error == kErrUnknownCommand && opcode == kOpcodeListDirectoryWithTime) {
+				LOG_DEBUG("ListDirectoryWithTime unsupported, falling back to ListDirectory");
+				_with_time_supported = false;
+				continue; // Same offset, plain opcode
+			}
+
+			if (error == kErrEOF) {
+				return Result::Success;
+			}
+
+			if (offset == 0 && (error == kErrFileNotFound || error == kErrFailErrno)) {
+				return Result::FileNotFound;
+			}
+
+			LOG_DEBUG("FTP list of " << path << " failed with error " << static_cast<int>(error)
+				  << " at offset " << offset);
+			return Result::ProtocolError;
+		}
+
+		const uint32_t previous_offset = offset;
+		parse_entries(reply, entries, offset);
+
+		// An ACK that advances nothing would loop forever; treat it as the end
+		if (offset == previous_offset) {
+			return Result::Success;
+		}
+	}
+
+	return Result::Stopped;
+}

--- a/src/FtpListClient.hpp
+++ b/src/FtpListClient.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <mavsdk/system.h>
+#include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Minimal MAVLink FTP client for directory listings.
+//
+// MAVSDK's Ftp plugin discards the size and modification-time fields from list
+// replies, but those are exactly what identifies a log file. This implements
+// ListDirectory / ListDirectoryWithTime over MavlinkPassthrough and keeps the
+// full entries. Bulk transfers still go through MAVSDK's Ftp plugin.
+//
+// Delete this once a MAVSDK release carries mavlink/MAVSDK#2891, which returns
+// listings as Ftp::FilesystemEntry (name, entry_type, size_bytes,
+// modification_time_s) and makes this redundant. It is on MAVSDK main but not
+// in any release up to v3.17.2.
+//
+// ListDirectoryWithTime is tried first and the client falls back to plain
+// ListDirectory when the server NAKs it with "unknown command" (ArduPilot and
+// PX4 releases before v1.17 do).
+//
+// One request is in flight at a time and requests are issued from a single
+// thread; only stop() may be called from another.
+class FtpListClient
+{
+public:
+	struct Entry {
+		std::string name;
+		bool is_directory {false};
+		uint32_t size_bytes {0};
+		std::optional<int64_t> mtime_utc; // Requires ListDirectoryWithTime support
+	};
+
+	enum class Result {
+		Success,
+		Timeout,      // No reply after retries, FTP likely disabled
+		FileNotFound, // Directory does not exist
+		ProtocolError,
+		Stopped
+	};
+
+	explicit FtpListClient(std::shared_ptr<mavsdk::System> system);
+	~FtpListClient();
+
+	// Closes any sessions a previous (possibly crashed) client left open on the
+	// vehicle. Best effort: PX4 only has a single FTP session and a stale one
+	// blocks transfers until it is reset.
+	void reset_sessions();
+
+	Result list_directory(const std::string& path, std::vector<Entry>& entries);
+
+	void stop();
+
+private:
+	// From the MAV_FTP_OPCODE enum in the MAVLink specification
+	static constexpr uint8_t kOpcodeResetSessions = 2;
+	static constexpr uint8_t kOpcodeListDirectory = 3;
+	static constexpr uint8_t kOpcodeListDirectoryWithTime = 16;
+	static constexpr uint8_t kOpcodeAck = 128;
+	static constexpr uint8_t kOpcodeNak = 129;
+
+	// From the MAV_FTP_ERR enum
+	static constexpr uint8_t kErrFailErrno = 2;
+	static constexpr uint8_t kErrEOF = 6;
+	static constexpr uint8_t kErrUnknownCommand = 7;
+	static constexpr uint8_t kErrFileNotFound = 10;
+
+	static constexpr size_t kMaxDataLength = 239;
+
+	// mavlink_file_transfer_protocol_t.payload is 251 bytes: this 12 byte
+	// header followed by kMaxDataLength bytes of data.
+	struct __attribute__((packed)) PayloadHeader {
+		uint16_t seq_number;
+		uint8_t session;
+		uint8_t opcode;
+		uint8_t size;
+		uint8_t req_opcode;
+		uint8_t burst_complete;
+		uint8_t padding;
+		uint32_t offset;
+		uint8_t data[kMaxDataLength];
+	};
+
+	static_assert(sizeof(PayloadHeader) == 251, "PayloadHeader must fill the FILE_TRANSFER_PROTOCOL payload");
+
+	void handle_message(const mavlink_message_t& message);
+	bool transact(uint8_t opcode, const std::string& path, uint32_t offset, PayloadHeader& reply);
+	void send_request(const PayloadHeader& request);
+
+	static void parse_entries(const PayloadHeader& reply, std::vector<Entry>& entries, uint32_t& next_offset);
+
+	std::shared_ptr<mavsdk::MavlinkPassthrough> _passthrough;
+	mavsdk::MavlinkPassthrough::MessageHandle _subscription;
+
+	std::mutex _mutex;
+	std::condition_variable _cv;
+	std::optional<PayloadHeader> _reply;
+	uint16_t _expected_seq {0};
+	std::optional<uint8_t> _expected_req_opcode;
+
+	uint16_t _seq {0};
+	bool _with_time_supported {true}; // Optimistic until the server NAKs it
+
+	std::atomic<bool> _should_exit {false};
+};

--- a/src/FtpLogFetcher.cpp
+++ b/src/FtpLogFetcher.cpp
@@ -1,0 +1,324 @@
+#include "FtpLogFetcher.hpp"
+#include "Log.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <future>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+// "@MAV_LOG" is the virtual log directory from the MAVLink FTP specification
+// (PX4 >= v1.17). The physical paths cover firmware that predates it.
+constexpr const char* kProbeRoots[] = {
+	"@MAV_LOG",
+	"/fs/microsd/log", // PX4
+	"/APM/LOGS",       // ArduPilot
+};
+
+bool ends_with_ignore_case(const std::string& text, const std::string& suffix)
+{
+	if (text.size() < suffix.size()) {
+		return false;
+	}
+
+	const size_t offset = text.size() - suffix.size();
+
+	for (size_t i = 0; i < suffix.size(); i++) {
+		if (std::tolower(static_cast<unsigned char>(text[offset + i]))
+		    != std::tolower(static_cast<unsigned char>(suffix[i]))) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool is_log_file(const std::string& name)
+{
+	return ends_with_ignore_case(name, ".ulg") || ends_with_ignore_case(name, ".bin");
+}
+
+// PX4 writes logs as <root>/<YYYY-MM-DD>/<HH_MM_SS>.ulg. The parsed time is the
+// log start; used when the vehicle cannot report modification times.
+std::optional<int64_t> parse_px4_start_time(const std::string& directory, const std::string& filename)
+{
+	const std::string stem = fs::path(filename).stem().string();
+
+	if (directory.size() != 10 || stem.size() != 8) {
+		return std::nullopt;
+	}
+
+	std::tm tm {};
+
+	if (sscanf(directory.c_str(), "%4d-%2d-%2d", &tm.tm_year, &tm.tm_mon, &tm.tm_mday) != 3) {
+		return std::nullopt;
+	}
+
+	if (sscanf(stem.c_str(), "%2d_%2d_%2d", &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 3) {
+		return std::nullopt;
+	}
+
+	tm.tm_year -= 1900;
+	tm.tm_mon -= 1;
+
+	return static_cast<int64_t>(timegm(&tm));
+}
+
+std::string join_path(const std::string& directory, const std::string& name)
+{
+	if (!directory.empty() && directory.back() == '/') {
+		return directory + name;
+	}
+
+	return directory + "/" + name;
+}
+
+} // namespace
+
+FtpLogFetcher::FtpLogFetcher(std::shared_ptr<mavsdk::System> system, const FtpLogFetcher::Settings& settings)
+	: _list_client(std::make_shared<FtpListClient>(system))
+	, _ftp(std::make_shared<mavsdk::Ftp>(system))
+	, _settings(settings)
+{
+	std::error_code ec;
+	fs::create_directories(_settings.temp_directory, ec);
+}
+
+void FtpLogFetcher::stop()
+{
+	_should_exit = true;
+	_list_client->stop();
+}
+
+void FtpLogFetcher::reset_sessions()
+{
+	_list_client->reset_sessions();
+}
+
+bool FtpLogFetcher::refresh()
+{
+	if (_root.empty()) {
+		// The override, when set, is the only candidate
+		std::vector<std::string> roots;
+
+		if (_settings.remote_directory.empty()) {
+			roots.assign(std::begin(kProbeRoots), std::end(kProbeRoots));
+
+		} else {
+			roots.push_back(_settings.remote_directory);
+		}
+
+		for (const auto& root : roots) {
+			std::vector<RemoteLog> logs;
+
+			if (build_index(root, logs)) {
+				_root = root;
+				publish_index(std::move(logs));
+				_reported_unavailable = false;
+				LOG("MAVLink FTP available, indexed " << _logs.size() << " logs in " << _root);
+				return true;
+			}
+		}
+
+		if (!_reported_unavailable) {
+			LOG("Could not index vehicle logs over MAVLink FTP. "
+			    "Make sure the autopilot has MAVLink FTP enabled on this link.");
+			_reported_unavailable = true;
+		}
+
+		return false;
+	}
+
+	std::vector<RemoteLog> logs;
+
+	if (build_index(_root, logs)) {
+		publish_index(std::move(logs));
+		return true;
+	}
+
+	// The directory may have moved out from under us (SD card swap, firmware
+	// update). Forget the root so the next refresh probes again.
+	LOG_DEBUG("Re-indexing " << _root << " failed, will re-probe");
+	_root.clear();
+	_logs.clear();
+
+	return false;
+}
+
+void FtpLogFetcher::publish_index(std::vector<RemoteLog>&& logs)
+{
+	std::map<std::string, uint32_t> sizes;
+
+	for (auto& log : logs) {
+		auto previous = _previous_sizes.find(log.relative_path);
+		log.stable = previous != _previous_sizes.end() && previous->second == log.size_bytes;
+		sizes.emplace(log.relative_path, log.size_bytes);
+	}
+
+	_previous_sizes = std::move(sizes);
+	_logs = std::move(logs);
+}
+
+bool FtpLogFetcher::build_index(const std::string& root, std::vector<RemoteLog>& logs)
+{
+	std::vector<FtpListClient::Entry> entries;
+
+	if (_list_client->list_directory(root, entries) != FtpListClient::Result::Success) {
+		return false;
+	}
+
+	std::vector<std::string> subdirectories;
+
+	for (const auto& entry : entries) {
+		if (entry.is_directory) {
+			if (entry.name != "." && entry.name != "..") {
+				subdirectories.push_back(entry.name);
+			}
+
+		} else if (is_log_file(entry.name)) {
+			RemoteLog log;
+			log.relative_path = entry.name;
+			log.size_bytes = entry.size_bytes;
+			log.time_utc = entry.mtime_utc;
+			logs.push_back(log);
+		}
+	}
+
+	// PX4 nests logs one directory deep (<root>/<date>/<time>.ulg). A partial
+	// index would make missing logs look deleted, so any listing failure fails
+	// the whole refresh.
+	for (const auto& subdirectory : subdirectories) {
+		if (_should_exit) {
+			return false;
+		}
+
+		std::vector<FtpListClient::Entry> sub_entries;
+
+		if (_list_client->list_directory(join_path(root, subdirectory), sub_entries)
+		    != FtpListClient::Result::Success) {
+			LOG_DEBUG("Listing " << join_path(root, subdirectory) << " failed");
+			return false;
+		}
+
+		for (const auto& entry : sub_entries) {
+			if (entry.is_directory || !is_log_file(entry.name)) {
+				continue;
+			}
+
+			RemoteLog log;
+			log.relative_path = subdirectory + "/" + entry.name;
+			log.size_bytes = entry.size_bytes;
+			log.time_utc = entry.mtime_utc;
+
+			if (!log.time_utc.has_value()) {
+				log.time_utc = parse_px4_start_time(subdirectory, entry.name);
+			}
+
+			logs.push_back(log);
+		}
+	}
+
+	return true;
+}
+
+bool FtpLogFetcher::download(const RemoteLog& log, const std::string& local_path,
+			     const FtpLogFetcher::ProgressCallback& progress)
+{
+	std::error_code ec;
+	fs::create_directories(_settings.temp_directory, ec);
+
+	const std::string remote_path = join_path(_root, log.relative_path);
+
+	// MAVSDK writes to <local_dir>/<remote basename>, so stage the transfer and
+	// move it into place afterwards. A partial file never appears in the logs
+	// directory.
+	const std::string staged_path = join_path(_settings.temp_directory, fs::path(log.relative_path).filename().string());
+	fs::remove(staged_path, ec);
+
+	struct Transfer {
+		std::promise<mavsdk::Ftp::Result> promise;
+		std::atomic<bool> settled {false};
+	};
+
+	// Shared so the callback stays valid if we abandon the wait on shutdown
+	auto transfer = std::make_shared<Transfer>();
+	auto future_result = transfer->promise.get_future();
+
+	_ftp->download_async(remote_path, _settings.temp_directory, _settings.use_burst,
+	[transfer, progress](mavsdk::Ftp::Result result, mavsdk::Ftp::ProgressData data) {
+		if (transfer->settled) {
+			return;
+		}
+
+		if (result == mavsdk::Ftp::Result::Next) {
+			if (progress) {
+				progress(data.bytes_transferred, data.total_bytes);
+			}
+
+			return;
+		}
+
+		transfer->settled = true;
+		transfer->promise.set_value(result);
+	});
+
+	// MAVSDK offers no way to cancel the transfer, so on shutdown the wait is
+	// abandoned instead of blocking until MAVSDK times out on its own.
+	while (future_result.wait_for(std::chrono::milliseconds(500)) != std::future_status::ready) {
+		if (_should_exit) {
+			transfer->settled = true;
+			fs::remove(staged_path, ec);
+			return false;
+		}
+	}
+
+	const auto result = future_result.get();
+
+	if (result != mavsdk::Ftp::Result::Success) {
+		LOG("FTP download of " << remote_path << " failed: " << result);
+		fs::remove(staged_path, ec);
+		return false;
+	}
+
+	if (!fs::exists(staged_path)) {
+		LOG("FTP reported success but " << staged_path << " is missing");
+		return false;
+	}
+
+	const uint32_t downloaded_size = static_cast<uint32_t>(fs::file_size(staged_path, ec));
+
+	if (downloaded_size != log.size_bytes) {
+		// The log grew or was rotated since the listing; the next refresh will
+		// index the current state.
+		LOG("Size mismatch for " << remote_path << ": got " << downloaded_size
+		    << " bytes, expected " << log.size_bytes);
+		fs::remove(staged_path, ec);
+		return false;
+	}
+
+	fs::remove(local_path, ec);
+	ec.clear();
+	fs::rename(staged_path, local_path, ec);
+
+	if (ec) {
+		// Different filesystems, fall back to a copy
+		ec.clear();
+		fs::copy_file(staged_path, local_path, fs::copy_options::overwrite_existing, ec);
+		std::error_code remove_ec;
+		fs::remove(staged_path, remove_ec);
+
+		if (ec) {
+			LOG("Failed to move " << staged_path << " to " << local_path << ": " << ec.message());
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/FtpLogFetcher.hpp
+++ b/src/FtpLogFetcher.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <mavsdk/system.h>
+#include <mavsdk/plugins/ftp/ftp.h>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "FtpListClient.hpp"
+
+// Indexes and downloads flight logs over MAVLink FTP.
+//
+// FILE_TRANSFER_PROTOCOL (msg 110) is addressed, and both PX4 and ArduPilot
+// send replies back to the requesting sysid/compid, so everything here is
+// unicast between the vehicle and logloader. The classic log protocol's
+// LOG_ENTRY / LOG_DATA (msgs 118/120) carry no target fields, which forces a
+// router in between to copy them to every endpoint it serves; logloader does
+// not use it at all.
+//
+// The vehicle log directory is probed at "@MAV_LOG" (the virtual directory the
+// MAVLink FTP spec defines for exactly this), then at the physical locations
+// used by PX4 and ArduPilot.
+class FtpLogFetcher
+{
+public:
+	struct RemoteLog {
+		// Path below the log root. The root can change (e.g. a firmware update
+		// that adds @MAV_LOG support), the relative path cannot, so identity is
+		// derived from this plus the size.
+		std::string relative_path;
+		uint32_t size_bytes {0};
+		// Modification time when the vehicle supports ListDirectoryWithTime,
+		// otherwise the start time PX4 encodes in the path, otherwise unknown.
+		std::optional<int64_t> time_utc;
+		// False while the file is still growing, i.e. the log the vehicle is
+		// writing right now. See refresh().
+		bool stable {false};
+	};
+
+	struct Settings {
+		std::string temp_directory;   // Scratch space for in-progress transfers
+		std::string remote_directory; // Empty probes the known locations
+		bool use_burst {true};
+	};
+
+	using ProgressCallback = std::function<void(uint32_t bytes_transferred, uint32_t total_bytes)>;
+
+	FtpLogFetcher(std::shared_ptr<mavsdk::System> system, const Settings& settings);
+
+	// Closes any FTP session a previous run left open on the vehicle
+	void reset_sessions();
+
+	// (Re)indexes the vehicle log directory, probing for it first when it is
+	// not known yet. Returns true only when a complete index was built, so a
+	// missing log can be trusted to actually be gone from the vehicle.
+	//
+	// A log is marked stable once two consecutive listings agree on its size.
+	// The log the vehicle is currently writing keeps growing, and downloading
+	// it would only produce a file that no longer matches what was listed.
+	bool refresh();
+
+	bool available() const { return !_root.empty(); }
+	const std::string& root() const { return _root; }
+	const std::vector<RemoteLog>& logs() const { return _logs; }
+
+	// Downloads a log into local_path, staging the transfer in temp_directory
+	// so partial files never appear next to finished ones. The size reported by
+	// the directory listing must match or the download is discarded.
+	bool download(const RemoteLog& log, const std::string& local_path, const ProgressCallback& progress);
+
+	void stop();
+
+private:
+	bool build_index(const std::string& root, std::vector<RemoteLog>& logs);
+	void publish_index(std::vector<RemoteLog>&& logs);
+
+	std::shared_ptr<FtpListClient> _list_client;
+	std::shared_ptr<mavsdk::Ftp> _ftp;
+	Settings _settings;
+
+	std::string _root;
+	std::vector<RemoteLog> _logs;
+
+	// Sizes from the previous listing, keyed by relative path
+	std::map<std::string, uint32_t> _previous_sizes;
+
+	bool _reported_unavailable {false};
+
+	std::atomic<bool> _should_exit {false};
+};

--- a/src/LogLoader.cpp
+++ b/src/LogLoader.cpp
@@ -1,12 +1,29 @@
 #include "LogLoader.hpp"
 #include "Log.hpp"
-#include <iostream>
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
 #include <filesystem>
-#include <future>
-#include <regex>
-#include <fstream>
+#include <iomanip>
+#include <iostream>
 
 namespace fs = std::filesystem;
+
+namespace
+{
+
+std::string iso8601_utc(int64_t time_utc)
+{
+	char buffer[sizeof "2018-08-31T20:50:42Z"];
+	const time_t as_time_t = static_cast<time_t>(time_utc);
+	std::tm tm {};
+	gmtime_r(&as_time_t, &tm);
+	strftime(buffer, sizeof(buffer), "%FT%TZ", &tm);
+	return buffer;
+}
+
+} // namespace
 
 LogLoader::LogLoader(const LogLoader::Settings& settings)
 	: _settings(settings)
@@ -18,6 +35,10 @@ LogLoader::LogLoader(const LogLoader::Settings& settings)
 	});
 
 	_logs_directory = _settings.application_directory + "logs/";
+
+	// Both databases live in the application directory, so it has to exist
+	// before the server interfaces open them
+	fs::create_directories(_logs_directory);
 
 	// Setup local server interface
 	ServerInterface::Settings local_server_settings = {
@@ -43,8 +64,6 @@ LogLoader::LogLoader(const LogLoader::Settings& settings)
 	_remote_server = std::make_shared<ServerInterface>(remote_server_settings);
 
 	std::cout << std::fixed << std::setprecision(8);
-
-	fs::create_directories(_logs_directory);
 }
 
 void LogLoader::stop()
@@ -54,6 +73,17 @@ void LogLoader::stop()
 		_should_exit = true;
 	}
 	_exit_cv.notify_all();
+
+	if (_ftp_fetcher) {
+		_ftp_fetcher->stop();
+	}
+}
+
+bool LogLoader::wait_for(std::chrono::seconds duration)
+{
+	std::unique_lock<std::mutex> lock(_exit_cv_mutex);
+	_exit_cv.wait_for(lock, duration, [this] { return _should_exit.load(); });
+	return _should_exit;
 }
 
 bool LogLoader::wait_for_mavsdk_connection(double timeout_ms)
@@ -78,8 +108,19 @@ bool LogLoader::wait_for_mavsdk_connection(double timeout_ms)
 	LOG("Connected.");
 
 	// MAVSDK plugins
-	_log_files = std::make_shared<mavsdk::LogFiles>(system.value());
 	_telemetry = std::make_shared<mavsdk::Telemetry>(system.value());
+
+	FtpLogFetcher::Settings ftp_settings = {
+		.temp_directory = _settings.application_directory + "tmp/",
+		.remote_directory = _settings.remote_log_directory,
+		.use_burst = _settings.ftp_use_burst,
+	};
+
+	_ftp_fetcher = std::make_shared<FtpLogFetcher>(system.value(), ftp_settings);
+
+	// PX4 serves a single FTP session, so one left open by a previous run (a
+	// hard kill mid-transfer) blocks every transfer until the vehicle reboots.
+	_ftp_fetcher->reset_sessions();
 
 	return true;
 }
@@ -110,29 +151,19 @@ void LogLoader::run()
 			std::this_thread::sleep_for(std::chrono::seconds(3));
 		}
 
-		// TODO:
-		// - request log entries at boot after connecting only
-		// - during runtime gate the log entry request on logger on/off events
-		if (!request_log_entries()) {
-			LOG_DEBUG("Failed to get logs");
-			std::this_thread::sleep_for(std::chrono::seconds(5));
+		if (!refresh_log_index()) {
+			if (wait_for(std::chrono::seconds(5))) {
+				break;
+			}
+
 			continue;
 		}
 
-		uint32_t total_to_download = _local_server->num_logs_to_download();
-		uint32_t num_remaining = total_to_download;
+		download_pending_logs();
 
-		while (!_should_exit && num_remaining) {
-			// Download logs until we should exit or there are none left to download
-			LOG("Downloading log " << total_to_download - num_remaining + 1 << "/" << total_to_download);
-			download_next_log();
-			num_remaining = _local_server->num_logs_to_download();
-		}
-
-		// Periodically request log list
-		if (!_should_exit) {
-			std::unique_lock<std::mutex> lock(_exit_cv_mutex);
-			_exit_cv.wait_for(lock, std::chrono::seconds(30), [this] { return _should_exit.load(); });
+		// Periodically re-index the vehicle
+		if (wait_for(std::chrono::seconds(30))) {
+			break;
 		}
 	}
 
@@ -140,150 +171,180 @@ void LogLoader::run()
 	upload_thread.join();
 }
 
-bool LogLoader::request_log_entries()
+bool LogLoader::refresh_log_index()
 {
-	LOG_DEBUG("Requesting log entries...");
+	auto request_start = std::chrono::steady_clock::now();
 
-	// Debug profiling code. We need to check how this performs with 100+ logs
-	auto request_start = std::chrono::high_resolution_clock::now();
-	auto entries_result = _log_files->get_entries();
-
-	//  Store log entries
-	_log_entries = entries_result.second;
-
-	auto request_end = std::chrono::high_resolution_clock::now();
-
-	std::chrono::duration<double> request_duration = request_end - request_start;
-	LOG_DEBUG("Received " << _log_entries.size() << "log entries in " << request_duration.count() << " seconds");
-
-	if (entries_result.first != mavsdk::LogFiles::Result::Success) {
-		LOG("Error getting log entries");
+	if (!_ftp_fetcher->refresh()) {
 		return false;
 	}
 
-	// Time the database addition
-	auto db_start = std::chrono::high_resolution_clock::now();
+	const auto& logs = _ftp_fetcher->logs();
+	size_t growing = 0;
 
-	for (const auto& entry : _log_entries) {
-		_local_server->add_log_entry(entry);
-		_remote_server->add_log_entry(entry);
+	for (const auto& log : logs) {
+		if (!log.stable) {
+			// Almost certainly the log being written right now. Leave it out of
+			// the databases entirely until it stops changing, so it never
+			// enters the download queue at a size it will not keep.
+			growing++;
+			continue;
+		}
+
+		ServerInterface::LogEntry entry;
+		entry.remote_path = log.relative_path;
+		entry.size_bytes = log.size_bytes;
+		entry.date = log.time_utc.has_value() ? iso8601_utc(log.time_utc.value()) : "";
+		entry.uuid = ServerInterface::generate_uuid(entry.remote_path, entry.size_bytes);
+
+		_local_server->sync_log(entry);
+		_remote_server->sync_log(entry);
 	}
 
-	auto db_end = std::chrono::high_resolution_clock::now();
-	std::chrono::duration<double> db_duration = db_end - db_start;
-
-	LOG_DEBUG("Added log entries to databases in " << db_duration.count() << " seconds");
-	LOG_DEBUG("Total processing time: " << (request_duration + db_duration).count() << " seconds");
+	std::chrono::duration<double> duration = std::chrono::steady_clock::now() - request_start;
+	LOG_DEBUG("Indexed " << logs.size() - growing << " of " << logs.size() << " logs in "
+		  << duration.count() << " seconds (" << growing << " still being written)");
 
 	return true;
 }
 
-void LogLoader::download_next_log()
+const FtpLogFetcher::RemoteLog* LogLoader::find_remote_log(const ServerInterface::DatabaseEntry& db_entry) const
 {
-	// Get one undownloaded log, use the local server for query
-	ServerInterface::DatabaseEntry db_entry = _local_server->get_next_log_to_download();
+	for (const auto& log : _ftp_fetcher->logs()) {
+		if (log.relative_path == db_entry.remote_path && log.size_bytes == db_entry.size_bytes) {
+			return &log;
+		}
+	}
 
-	if (db_entry.uuid.empty()) {
+	return nullptr;
+}
+
+void LogLoader::download_pending_logs()
+{
+	auto pending = _local_server->get_logs_to_download();
+
+	if (pending.empty()) {
 		return;
 	}
 
-	// Find the corresponding log entry in the list from the vehicle
-	for (const auto& entry : _log_entries) {
-		// Match by UUID (which is based on date and size)
-		std::string uuid = ServerInterface::generate_uuid(entry);
+	// Retry the logs that have failed the least first, so a file that cannot be
+	// fetched never blocks the ones behind it.
+	std::stable_sort(pending.begin(), pending.end(),
+	[this](const ServerInterface::DatabaseEntry & lhs, const ServerInterface::DatabaseEntry & rhs) {
+		auto lhs_it = _download_failures.find(lhs.uuid);
+		auto rhs_it = _download_failures.find(rhs.uuid);
+		const int lhs_failures = lhs_it == _download_failures.end() ? 0 : lhs_it->second;
+		const int rhs_failures = rhs_it == _download_failures.end() ? 0 : rhs_it->second;
+		return lhs_failures < rhs_failures;
+	});
 
-		if (uuid == db_entry.uuid) {
-			if (download_log(entry)) {
-				// Update downloaded status in both databases
-				_local_server->update_download_status(uuid, true);
-				_remote_server->update_download_status(uuid, true);
-			}
+	size_t index = 0;
 
+	for (const auto& db_entry : pending) {
+		if (_should_exit) {
 			return;
 		}
-	}
 
-	// Couldn't find matching entry in _log_entries
-	// This could happen if the log is no longer available on the vehicle
-	// Mark it as processed to avoid trying again in both databases
-	_local_server->update_download_status(db_entry.uuid, true);
-	_remote_server->update_download_status(db_entry.uuid, true);
+		// Downloading competes with the logger for the SD card, so give the
+		// rest of the queue back to the outer loop as soon as the vehicle arms
+		if (_telemetry->armed()) {
+			LOG("Vehicle armed, pausing downloads");
+			return;
+		}
 
-	return;
-}
+		index++;
 
-bool LogLoader::download_log(const mavsdk::LogFiles::Entry& entry)
-{
-	auto prom = std::promise<mavsdk::LogFiles::Result> {};
-	auto future_result = prom.get_future();
-	auto download_path = _local_server->filepath_from_entry(entry);
+		const FtpLogFetcher::RemoteLog* log = find_remote_log(db_entry);
 
-	// Check and delete file if it already exists. This can occur due to partial download.
-	if (fs::exists(download_path)) {
-		LOG("Found existing file, removing: " << download_path);
+		if (log == nullptr) {
+			// The index is only published when the whole directory listed, so
+			// a log that is not in it is genuinely gone from the vehicle.
+			LOG_DEBUG("Log " << db_entry.remote_path << " is no longer on the vehicle, forgetting it");
+			_local_server->delete_log(db_entry.uuid);
+			_remote_server->delete_log(db_entry.uuid);
+			continue;
+		}
 
-		try {
-			fs::remove(download_path);
+		LOG("Downloading log " << index << "/" << pending.size() << ": " << db_entry.remote_path);
 
-		} catch (const fs::filesystem_error& e) {
-			LOG("Error removing existing file: " << e.what());
-			return false;
+		if (download_log(db_entry, *log)) {
+			_download_failures.erase(db_entry.uuid);
+
+		} else {
+			_download_failures[db_entry.uuid]++;
 		}
 	}
+}
 
-	LOG("Downloading " << download_path);
+std::string LogLoader::local_path_for(const ServerInterface::DatabaseEntry& db_entry)
+{
+	std::string name = db_entry.remote_path;
+	std::replace(name.begin(), name.end(), '/', '_');
+
+	const std::string path = _logs_directory + name;
+
+	// ArduPilot reuses log file names once its numbering wraps at
+	// LOG_MAX_FILES, so the name may already belong to a log we still have.
+	if (_local_server->local_path_in_use(path, db_entry.uuid)) {
+		return _logs_directory + db_entry.uuid.substr(0, 8) + "_" + name;
+	}
+
+	return path;
+}
+
+bool LogLoader::download_log(const ServerInterface::DatabaseEntry& db_entry, const FtpLogFetcher::RemoteLog& log)
+{
+	const std::string local_path = local_path_for(db_entry);
 
 	auto time_start = std::chrono::steady_clock::now();
 
-	_log_files->download_log_file_async(
-		entry,
-		download_path,
-	[&prom, &entry, &time_start, this](mavsdk::LogFiles::Result result, mavsdk::LogFiles::ProgressData progress) {
+	FtpLogFetcher::ProgressCallback progress;
 
-		if (_download_cancelled) return;
+#ifdef DEBUG_BUILD
+	// Held by the callback rather than captured by reference: MAVSDK owns the
+	// callback and this function returns without it on shutdown.
+	auto last_print = std::make_shared<std::chrono::steady_clock::time_point>(time_start);
 
-		auto now = std::chrono::steady_clock::now();
+	progress = [remote_path = db_entry.remote_path, size_bytes = db_entry.size_bytes, time_start, last_print](
+	uint32_t bytes_transferred, uint32_t total_bytes) {
+		const auto now = std::chrono::steady_clock::now();
 
-		if (_should_exit) {
-			_download_cancelled = true;
-			prom.set_value(mavsdk::LogFiles::Result::Timeout);
-			std::cout << std::endl << "Download cancelled.. exiting" << std::endl;
+		// One line per chunk buries everything else in the journal
+		if (now - *last_print < std::chrono::seconds(1)) {
 			return;
 		}
 
-#ifdef DEBUG_BUILD
-		// Calculate data rate in Kbps
-		double rate_kbps = ((progress.progress * entry.size_bytes * 8.0)) / std::chrono::duration_cast<std::chrono::milliseconds>(now -
-				   time_start).count(); // Convert bytes to bits and then to Kbps
+		*last_print = now;
+
+		auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - time_start).count();
+		double rate_kbps = elapsed_ms > 0 ? (bytes_transferred * 8.0) / elapsed_ms : 0.;
+		int percent = total_bytes > 0 ? int((100.0 * bytes_transferred) / total_bytes) : 0;
 
 		LOG_DEBUG("Downloading: "
-			  << std::setw(24) << std::left << entry.date
-			  << std::setw(8) << std::fixed << std::setprecision(2) << entry.size_bytes / 1e6 << "MB"
-			  << std::setw(6) << std::right << int(progress.progress * 100.0f) << "%"
+			  << std::setw(24) << std::left << remote_path
+			  << std::setw(8) << std::fixed << std::setprecision(2) << size_bytes / 1e6 << "MB"
+			  << std::setw(6) << std::right << percent << "%"
 			  << std::setw(12) << std::fixed << std::setprecision(2) << rate_kbps << " Kbps"
 			  << std::flush);
-#else
-		(void)progress;
+	};
 #endif
 
-		if (result != mavsdk::LogFiles::Result::Next) {
-			double seconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - time_start).count() / 1000.;
-			LOG("Finished in " << std::setprecision(2) << seconds << " seconds");
-			prom.set_value(result);
-		}
-	});
-
-	auto result = future_result.get();
-
-	std::cout << std::endl;
-
-	bool success = result == mavsdk::LogFiles::Result::Success;
+	bool success = _ftp_fetcher->download(log, local_path, progress);
 
 	if (!success) {
 		LOG("Download failed");
+		return false;
 	}
 
-	return success;
+	double seconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+				 std::chrono::steady_clock::now() - time_start).count() / 1000.;
+	LOG("Finished in " << std::setprecision(2) << seconds << " seconds");
+
+	// Update downloaded status in both databases
+	_local_server->update_download_status(db_entry.uuid, local_path, true);
+	_remote_server->update_download_status(db_entry.uuid, local_path, true);
+
+	return true;
 }
 
 void LogLoader::upload_logs_thread()
@@ -339,7 +400,7 @@ void LogLoader::upload_pending_logs(std::shared_ptr<ServerInterface> server)
 			return;
 		}
 
-		ServerInterface::UploadResult result = server->upload_log(filepath);
+		ServerInterface::UploadResult result = server->upload_log(log_entry.uuid, filepath);
 
 		if (result.success) {
 			LOG("Log upload SUCCESS: " << result.message);
@@ -350,6 +411,8 @@ void LogLoader::upload_pending_logs(std::shared_ptr<ServerInterface> server)
 		} else {
 			LOG("Log upload TEMPORARILY FAILED (" << result.status_code << "): "
 			    << result.message << " - Will retry later");
+			// Retry on the next pass rather than hammering an unhappy server
+			return;
 		}
 	}
 }

--- a/src/LogLoader.hpp
+++ b/src/LogLoader.hpp
@@ -2,10 +2,11 @@
 
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/telemetry/telemetry.h>
-#include <mavsdk/plugins/log_files/log_files.h>
 #include <mavsdk/log_callback.h>
 #include <condition_variable>
+#include <map>
 
+#include "FtpLogFetcher.hpp"
 #include "ServerInterface.hpp"
 
 class LogLoader
@@ -19,6 +20,8 @@ public:
 		std::string application_directory;
 		bool upload_enabled;
 		bool public_logs;
+		std::string remote_log_directory; // Empty probes the known locations
+		bool ftp_use_burst;
 	};
 
 	LogLoader(const Settings& settings);
@@ -29,13 +32,18 @@ public:
 
 private:
 	// Download
-	bool request_log_entries();
-	void download_next_log();
-	bool download_log(const mavsdk::LogFiles::Entry& entry);
+	bool refresh_log_index();
+	void download_pending_logs();
+	bool download_log(const ServerInterface::DatabaseEntry& db_entry, const FtpLogFetcher::RemoteLog& log);
+	const FtpLogFetcher::RemoteLog* find_remote_log(const ServerInterface::DatabaseEntry& db_entry) const;
+	std::string local_path_for(const ServerInterface::DatabaseEntry& db_entry);
 
 	// Upload
 	void upload_logs_thread();
 	void upload_pending_logs(std::shared_ptr<ServerInterface> server);
+
+	// Returns true if we should exit
+	bool wait_for(std::chrono::seconds duration);
 
 	Settings _settings;
 	std::string _logs_directory;
@@ -46,11 +54,14 @@ private:
 
 	std::shared_ptr<mavsdk::Mavsdk> _mavsdk;
 	std::shared_ptr<mavsdk::Telemetry> _telemetry;
-	std::shared_ptr<mavsdk::LogFiles> _log_files;
-	std::vector<mavsdk::LogFiles::Entry> _log_entries;
+	std::shared_ptr<FtpLogFetcher> _ftp_fetcher;
+
+	// Consecutive download failures per log. A file the vehicle will not part
+	// with (a very large one that keeps timing out, say) is retried last so it
+	// cannot hold up everything behind it.
+	std::map<std::string, int> _download_failures;
 
 	std::atomic<bool> _should_exit = false;
-	std::atomic<bool> _download_cancelled = false;
 
 	std::condition_variable _exit_cv;
 	std::mutex _exit_cv_mutex;

--- a/src/ServerInterface.cpp
+++ b/src/ServerInterface.cpp
@@ -7,12 +7,33 @@
 #include <chrono>
 #include <ctime>
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <functional>
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
 
 namespace fs = std::filesystem;
+
+namespace
+{
+
+std::optional<int64_t> parse_iso8601_utc(const std::string& text)
+{
+	std::tm tm {};
+
+	if (sscanf(text.c_str(), "%4d-%2d-%2dT%2d:%2d:%2dZ",
+		   &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+		return std::nullopt;
+	}
+
+	tm.tm_year -= 1900;
+	tm.tm_mon -= 1;
+
+	return static_cast<int64_t>(timegm(&tm));
+}
+
+} // namespace
 
 ServerInterface::ServerInterface(const ServerInterface::Settings& settings)
 	: _settings(settings)
@@ -69,11 +90,11 @@ void ServerInterface::stop()
 	_should_exit = true;
 }
 
-std::string ServerInterface::generate_uuid(const mavsdk::LogFiles::Entry& entry)
+std::string ServerInterface::generate_uuid(const std::string& remote_path, uint32_t size_bytes)
 {
-	// Create a unique identifier based on date and size
+	// Create a unique identifier based on the remote path and size
 	std::stringstream ss;
-	ss << entry.date << "_" << entry.size_bytes;
+	ss << remote_path << "_" << size_bytes;
 
 	// Use a simple hash for the UUID
 	std::hash<std::string> hasher;
@@ -84,20 +105,18 @@ std::string ServerInterface::generate_uuid(const mavsdk::LogFiles::Entry& entry)
 	return ss.str();
 }
 
-bool ServerInterface::add_log_entry(const mavsdk::LogFiles::Entry& entry)
+bool ServerInterface::sync_log(const LogEntry& entry)
 {
-	std::string uuid = generate_uuid(entry);
-
 	// Check if the log already exists
 	sqlite3_stmt* stmt;
 	std::string check_query = "SELECT COUNT(*) FROM logs WHERE uuid = ?";
 
 	if (sqlite3_prepare_v2(_db, check_query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
-		std::cerr << "SQL error preparing add_log_entry check: " << sqlite3_errmsg(_db) << std::endl;
+		std::cerr << "SQL error preparing sync_log check: " << sqlite3_errmsg(_db) << std::endl;
 		return false;
 	}
 
-	sqlite3_bind_text(stmt, 1, uuid.c_str(), -1, SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 1, entry.uuid.c_str(), -1, SQLITE_STATIC);
 
 	bool exists = false;
 
@@ -113,28 +132,32 @@ bool ServerInterface::add_log_entry(const mavsdk::LogFiles::Entry& entry)
 
 	// Insert the log
 	std::string insert_query =
-		"INSERT INTO logs (uuid, id, date, size_bytes, downloaded, uploaded) "
-		"VALUES (?, ?, ?, ?, 0, 0)";
+		"INSERT INTO logs (uuid, remote_path, date, size_bytes, local_path, downloaded, uploaded) "
+		"VALUES (?, ?, ?, ?, '', 0, 0)";
 
 	if (sqlite3_prepare_v2(_db, insert_query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
-		std::cerr << "SQL error preparing add_log_entry insert: " << sqlite3_errmsg(_db) << std::endl;
+		std::cerr << "SQL error preparing sync_log insert: " << sqlite3_errmsg(_db) << std::endl;
 		return false;
 	}
 
-	sqlite3_bind_text(stmt, 1, uuid.c_str(), -1, SQLITE_STATIC);
-	sqlite3_bind_int(stmt, 2, entry.id);
+	sqlite3_bind_text(stmt, 1, entry.uuid.c_str(), -1, SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 2, entry.remote_path.c_str(), -1, SQLITE_STATIC);
 	sqlite3_bind_text(stmt, 3, entry.date.c_str(), -1, SQLITE_STATIC);
-	sqlite3_bind_int(stmt, 4, entry.size_bytes);
+	sqlite3_bind_int64(stmt, 4, entry.size_bytes);
 
 	bool success = sqlite3_step(stmt) == SQLITE_DONE;
 	sqlite3_finalize(stmt);
 
+	if (success) {
+		grandfather_from_legacy(entry);
+	}
+
 	return success;
 }
 
-bool ServerInterface::update_download_status(const std::string& uuid, bool downloaded)
+bool ServerInterface::update_download_status(const std::string& uuid, const std::string& local_path, bool downloaded)
 {
-	std::string query = "UPDATE logs SET downloaded = ? WHERE uuid = ?";
+	std::string query = "UPDATE logs SET downloaded = ?, local_path = ? WHERE uuid = ?";
 	sqlite3_stmt* stmt;
 
 	if (sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -143,12 +166,50 @@ bool ServerInterface::update_download_status(const std::string& uuid, bool downl
 	}
 
 	sqlite3_bind_int(stmt, 1, downloaded ? 1 : 0);
-	sqlite3_bind_text(stmt, 2, uuid.c_str(), -1, SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 2, local_path.c_str(), -1, SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 3, uuid.c_str(), -1, SQLITE_STATIC);
 
 	bool success = sqlite3_step(stmt) == SQLITE_DONE;
 	sqlite3_finalize(stmt);
 
 	return success;
+}
+
+bool ServerInterface::delete_log(const std::string& uuid)
+{
+	std::string query = "DELETE FROM logs WHERE uuid = ?";
+	sqlite3_stmt* stmt;
+
+	if (sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+		std::cerr << "SQL error preparing delete_log: " << sqlite3_errmsg(_db) << std::endl;
+		return false;
+	}
+
+	sqlite3_bind_text(stmt, 1, uuid.c_str(), -1, SQLITE_STATIC);
+
+	bool success = sqlite3_step(stmt) == SQLITE_DONE;
+	sqlite3_finalize(stmt);
+
+	return success;
+}
+
+bool ServerInterface::local_path_in_use(const std::string& local_path, const std::string& excluding_uuid)
+{
+	std::string query = "SELECT COUNT(*) FROM logs WHERE local_path = ? AND uuid != ?";
+	sqlite3_stmt* stmt;
+
+	if (sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+		std::cerr << "SQL error preparing local_path_in_use: " << sqlite3_errmsg(_db) << std::endl;
+		return false;
+	}
+
+	sqlite3_bind_text(stmt, 1, local_path.c_str(), -1, SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 2, excluding_uuid.c_str(), -1, SQLITE_STATIC);
+
+	bool in_use = sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_int(stmt, 0) > 0;
+	sqlite3_finalize(stmt);
+
+	return in_use;
 }
 
 uint32_t ServerInterface::num_logs_to_upload()
@@ -160,7 +221,7 @@ uint32_t ServerInterface::num_logs_to_upload()
 	sqlite3_stmt* stmt;
 	std::string query =
 		"SELECT COUNT(*) FROM logs "
-		"WHERE downloaded = 1 AND uploaded = 0 "
+		"WHERE downloaded = 1 AND uploaded = 0 AND local_path != '' "
 		"AND uuid NOT IN (SELECT uuid FROM blacklist)";
 
 	if (sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -189,8 +250,8 @@ ServerInterface::DatabaseEntry ServerInterface::get_next_log_to_upload()
 
 	sqlite3_stmt* stmt;
 	std::string query =
-		"SELECT uuid, id, date, size_bytes, downloaded, uploaded FROM logs "
-		"WHERE downloaded = 1 AND uploaded = 0 "
+		"SELECT uuid, remote_path, date, size_bytes, local_path, downloaded FROM logs "
+		"WHERE downloaded = 1 AND uploaded = 0 AND local_path != '' "
 		"AND uuid NOT IN (SELECT uuid FROM blacklist) "
 		"ORDER BY date DESC, size_bytes DESC LIMIT 1";
 
@@ -209,54 +270,14 @@ ServerInterface::DatabaseEntry ServerInterface::get_next_log_to_upload()
 	return entry;
 }
 
-ServerInterface::UploadResult ServerInterface::upload_log(const std::string& filepath)
+ServerInterface::UploadResult ServerInterface::upload_log(const std::string& uuid, const std::string& filepath)
 {
 	if (!_settings.upload_enabled || _should_exit) {
 		return {false, 0, "Upload disabled or shutting down"};
 	}
 
-	// Extract UUID from filename
-	std::string filename = fs::path(filepath).filename().string();
-	std::string uuid;
-
-	// Parse the ID and date from filename (assuming format like LOG0001_2023-04-15T12:34:56Z.ulg)
-	size_t underscore_pos = filename.find('_');
-	size_t dot_pos = filename.find_last_of('.');
-
-	if (underscore_pos != std::string::npos && dot_pos != std::string::npos) {
-		std::string id_part = filename.substr(3, underscore_pos - 3); // Skip "LOG" prefix
-		std::string date_part = filename.substr(underscore_pos + 1, dot_pos - underscore_pos - 1);
-
-		uint32_t id = std::stoi(id_part);
-		uint32_t size = fs::exists(filepath) ? fs::file_size(filepath) : 0;
-
-		// Create a log entry and generate UUID
-		mavsdk::LogFiles::Entry entry;
-		entry.id = id;
-		entry.date = date_part;
-		entry.size_bytes = size;
-
-		uuid = generate_uuid(entry);
-
-		// Add to database if not already there
-		sqlite3_stmt* stmt;
-		std::string check_query = "SELECT COUNT(*) FROM logs WHERE uuid = ?";
-
-		if (sqlite3_prepare_v2(_db, check_query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
-			sqlite3_bind_text(stmt, 1, uuid.c_str(), -1, SQLITE_STATIC);
-
-			if (sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_int(stmt, 0) == 0) {
-				// Log doesn't exist, add it
-				add_log_entry(entry);
-				update_download_status(uuid, true); // Mark as downloaded since we have the file
-			}
-
-			sqlite3_finalize(stmt);
-		}
-	}
-
 	if (uuid.empty()) {
-		return {false, 0, "Could not determine UUID from filename"};
+		return {false, 0, "Missing UUID"};
 	}
 
 	// Check if already blacklisted
@@ -330,45 +351,33 @@ uint32_t ServerInterface::num_logs_to_download()
 	return log_count;
 }
 
-ServerInterface::DatabaseEntry ServerInterface::get_next_log_to_download()
+std::vector<ServerInterface::DatabaseEntry> ServerInterface::get_logs_to_download()
 {
-	DatabaseEntry empty_entry;
-	empty_entry.uuid = ""; // Empty UUID indicates not found
+	std::vector<DatabaseEntry> entries;
 
 	sqlite3_stmt* stmt;
 	std::string query =
-		"SELECT uuid, id, date, size_bytes, downloaded, uploaded "
+		"SELECT uuid, remote_path, date, size_bytes, local_path, downloaded "
 		"FROM logs WHERE downloaded = 0 "
-		"ORDER BY date DESC, size_bytes DESC LIMIT 1";
+		"ORDER BY date DESC, remote_path DESC";
 
 	if (sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
-		std::cerr << "SQL error preparing get_next_log_to_download: " << sqlite3_errmsg(_db) << std::endl;
-		return empty_entry;
+		std::cerr << "SQL error preparing get_logs_to_download: " << sqlite3_errmsg(_db) << std::endl;
+		return entries;
 	}
 
-	DatabaseEntry entry = empty_entry;
-
-	if (sqlite3_step(stmt) == SQLITE_ROW) {
-		entry = row_to_db_entry(stmt);
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		entries.push_back(row_to_db_entry(stmt));
 	}
 
 	sqlite3_finalize(stmt);
-	return entry;
-}
-
-std::string ServerInterface::filepath_from_entry(const mavsdk::LogFiles::Entry& entry) const
-{
-	std::ostringstream ss;
-	ss << _settings.logs_directory << "LOG" << std::setfill('0') << std::setw(4) << entry.id << "_" << entry.date << ".ulg";
-	return ss.str();
+	return entries;
 }
 
 std::string ServerInterface::filepath_from_uuid(const std::string& uuid) const
 {
-	// Look up the log entry by UUID
 	sqlite3_stmt* stmt;
-	std::string query =
-		"SELECT id, date FROM logs WHERE uuid = ?";
+	std::string query = "SELECT local_path FROM logs WHERE uuid = ?";
 
 	if (sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
 		std::cerr << "SQL error preparing filepath_from_uuid: " << sqlite3_errmsg(_db) << std::endl;
@@ -380,14 +389,10 @@ std::string ServerInterface::filepath_from_uuid(const std::string& uuid) const
 	std::string filepath;
 
 	if (sqlite3_step(stmt) == SQLITE_ROW) {
-		int id = sqlite3_column_int(stmt, 0);
-		const unsigned char* date_text = sqlite3_column_text(stmt, 1);
+		const unsigned char* path_text = sqlite3_column_text(stmt, 0);
 
-		if (date_text != nullptr) {
-			std::string date = reinterpret_cast<const char*>(date_text);
-			std::ostringstream ss;
-			ss << _settings.logs_directory << "LOG" << std::setfill('0') << std::setw(4) << id << "_" << date << ".ulg";
-			filepath = ss.str();
+		if (path_text != nullptr) {
+			filepath = reinterpret_cast<const char*>(path_text);
 		}
 	}
 
@@ -496,13 +501,16 @@ bool ServerInterface::init_database()
 		return false;
 	}
 
+	migrate_legacy_schema();
+
 	// Create logs table
 	const char* create_logs_table =
 		"CREATE TABLE IF NOT EXISTS logs ("
 		"  uuid TEXT PRIMARY KEY,"  // UUID of the log
-		"  id INTEGER,"             // Original log ID
-		"  date TEXT,"              // ISO8601 date from log
+		"  remote_path TEXT,"       // Path relative to the vehicle log root
+		"  date TEXT,"              // ISO8601 date, empty when unknown
 		"  size_bytes INTEGER,"     // Size in bytes
+		"  local_path TEXT DEFAULT '',"   // Where the download ended up
 		"  downloaded INTEGER DEFAULT 0," // Has it been downloaded
 		"  uploaded INTEGER DEFAULT 0"   // Has it been uploaded
 		");";
@@ -517,6 +525,187 @@ bool ServerInterface::init_database()
 
 	bool success = execute_query(create_logs_table) && execute_query(create_blacklist_table);
 	return success;
+}
+
+bool ServerInterface::table_exists(const std::string& name) const
+{
+	sqlite3_stmt* stmt;
+	const char* query = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?";
+
+	if (sqlite3_prepare_v2(_db, query, -1, &stmt, nullptr) != SQLITE_OK) {
+		return false;
+	}
+
+	sqlite3_bind_text(stmt, 1, name.c_str(), -1, SQLITE_STATIC);
+
+	bool exists = sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_int(stmt, 0) > 0;
+	sqlite3_finalize(stmt);
+
+	return exists;
+}
+
+bool ServerInterface::column_exists(const std::string& table, const std::string& column) const
+{
+	sqlite3_stmt* stmt;
+	const char* query = "SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?";
+
+	if (sqlite3_prepare_v2(_db, query, -1, &stmt, nullptr) != SQLITE_OK) {
+		return false;
+	}
+
+	sqlite3_bind_text(stmt, 1, table.c_str(), -1, SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 2, column.c_str(), -1, SQLITE_STATIC);
+
+	bool exists = sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_int(stmt, 0) > 0;
+	sqlite3_finalize(stmt);
+
+	return exists;
+}
+
+void ServerInterface::migrate_legacy_schema()
+{
+	if (table_exists("logs_legacy") && !column_exists("logs_legacy", "migrated")) {
+		execute_query("ALTER TABLE logs_legacy ADD COLUMN migrated INTEGER DEFAULT 0");
+	}
+
+	// Pre-FTP databases keyed logs on (LOG_ENTRY date, size)
+	if (table_exists("logs") && !column_exists("logs", "remote_path")) {
+		LOG("Migrating " << _settings.db_path << " to the MAVLink FTP log schema");
+
+		if (table_exists("logs_legacy")) {
+			// An older logloader ran again after this one (the ARK-OS installer
+			// allows downgrades), so fold its state into the existing table.
+			execute_query(
+				"INSERT OR IGNORE INTO logs_legacy (uuid, id, date, size_bytes, downloaded, uploaded, migrated) "
+				"SELECT uuid, id, date, size_bytes, downloaded, uploaded, 0 FROM logs");
+			execute_query("DROP TABLE logs");
+
+		} else {
+			execute_query("ALTER TABLE logs RENAME TO logs_legacy");
+			execute_query("ALTER TABLE logs_legacy ADD COLUMN migrated INTEGER DEFAULT 0");
+		}
+	}
+
+	_has_legacy_table = table_exists("logs_legacy");
+}
+
+void ServerInterface::grandfather_from_legacy(const LogEntry& entry)
+{
+	if (!_has_legacy_table) {
+		return;
+	}
+
+	struct LegacyRow {
+		std::string uuid;
+		int id;
+		std::string date;
+		bool downloaded;
+		bool uploaded;
+	};
+
+	std::vector<LegacyRow> candidates;
+
+	sqlite3_stmt* stmt;
+
+	const char* query =
+		"SELECT uuid, id, date, downloaded, uploaded FROM logs_legacy "
+		"WHERE migrated = 0 AND size_bytes = ?";
+
+	if (sqlite3_prepare_v2(_db, query, -1, &stmt, nullptr) != SQLITE_OK) {
+		return;
+	}
+
+	sqlite3_bind_int64(stmt, 1, entry.size_bytes);
+
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		LegacyRow row;
+		const unsigned char* uuid_text = sqlite3_column_text(stmt, 0);
+		const unsigned char* date_text = sqlite3_column_text(stmt, 2);
+		row.uuid = uuid_text ? reinterpret_cast<const char*>(uuid_text) : "";
+		row.id = sqlite3_column_int(stmt, 1);
+		row.date = date_text ? reinterpret_cast<const char*>(date_text) : "";
+		row.downloaded = sqlite3_column_int(stmt, 3) != 0;
+		row.uploaded = sqlite3_column_int(stmt, 4) != 0;
+		candidates.push_back(row);
+	}
+
+	sqlite3_finalize(stmt);
+
+	if (candidates.empty()) {
+		return;
+	}
+
+	// The legacy date is the log's modification time; the new one is either
+	// that as well or the start time parsed from the path. Same log, so they
+	// are at most a flight apart. Without a time to compare, only an
+	// unambiguous single candidate is safe to claim.
+	const LegacyRow* match = nullptr;
+	const auto entry_time = parse_iso8601_utc(entry.date);
+
+	if (entry_time.has_value()) {
+		constexpr int64_t kMaxDelta = 48 * 3600;
+		int64_t best_delta = kMaxDelta;
+
+		for (const auto& candidate : candidates) {
+			const auto legacy_time = parse_iso8601_utc(candidate.date);
+
+			if (!legacy_time.has_value()) {
+				continue;
+			}
+
+			const int64_t delta = std::abs(legacy_time.value() - entry_time.value());
+
+			if (delta <= best_delta) {
+				best_delta = delta;
+				match = &candidate;
+			}
+		}
+
+	} else if (candidates.size() == 1) {
+		match = &candidates.front();
+	}
+
+	if (match == nullptr) {
+		return;
+	}
+
+	// Reconstruct the file name the legacy naming scheme used
+	std::ostringstream legacy_name;
+	legacy_name << _settings.logs_directory << "LOG" << std::setfill('0') << std::setw(4)
+		    << match->id << "_" << match->date << ".ulg";
+
+	const std::string legacy_path = legacy_name.str();
+	const bool file_exists = fs::exists(legacy_path);
+
+	// A log whose file went missing before it was uploaded is re-downloaded
+	const bool downloaded = match->downloaded && (file_exists || match->uploaded);
+	const std::string local_path = (match->downloaded && file_exists) ? legacy_path : "";
+
+	const char* update_query = "UPDATE logs SET downloaded = ?, uploaded = ?, local_path = ? WHERE uuid = ?";
+
+	if (sqlite3_prepare_v2(_db, update_query, -1, &stmt, nullptr) == SQLITE_OK) {
+		sqlite3_bind_int(stmt, 1, downloaded ? 1 : 0);
+		sqlite3_bind_int(stmt, 2, match->uploaded ? 1 : 0);
+		sqlite3_bind_text(stmt, 3, local_path.c_str(), -1, SQLITE_STATIC);
+		sqlite3_bind_text(stmt, 4, entry.uuid.c_str(), -1, SQLITE_STATIC);
+		sqlite3_step(stmt);
+		sqlite3_finalize(stmt);
+	}
+
+	if (is_blacklisted(match->uuid)) {
+		add_to_blacklist(entry.uuid, "Migrated from legacy uuid " + match->uuid);
+	}
+
+	const char* mark_query = "UPDATE logs_legacy SET migrated = 1 WHERE uuid = ?";
+
+	if (sqlite3_prepare_v2(_db, mark_query, -1, &stmt, nullptr) == SQLITE_OK) {
+		sqlite3_bind_text(stmt, 1, match->uuid.c_str(), -1, SQLITE_STATIC);
+		sqlite3_step(stmt);
+		sqlite3_finalize(stmt);
+	}
+
+	LOG_DEBUG("Migrated legacy log " << match->uuid << " -> " << entry.uuid
+		  << " (" << entry.remote_path << ")");
 }
 
 void ServerInterface::close_database()
@@ -574,27 +763,20 @@ ServerInterface::DatabaseEntry ServerInterface::row_to_db_entry(sqlite3_stmt* st
 	DatabaseEntry entry;
 
 	const unsigned char* uuid_text = sqlite3_column_text(stmt, 0);
+	entry.uuid = uuid_text ? reinterpret_cast<const char*>(uuid_text) : "";
 
-	if (uuid_text != nullptr) {
-		entry.uuid = reinterpret_cast<const char*>(uuid_text);
-
-	} else {
-		entry.uuid = "";
-	}
-
-	entry.id = sqlite3_column_int(stmt, 1);
+	const unsigned char* path_text = sqlite3_column_text(stmt, 1);
+	entry.remote_path = path_text ? reinterpret_cast<const char*>(path_text) : "";
 
 	const unsigned char* date_text = sqlite3_column_text(stmt, 2);
+	entry.date = date_text ? reinterpret_cast<const char*>(date_text) : "";
 
-	if (date_text != nullptr) {
-		entry.date = reinterpret_cast<const char*>(date_text);
+	entry.size_bytes = static_cast<uint32_t>(sqlite3_column_int64(stmt, 3));
 
-	} else {
-		entry.date = "";
-	}
+	const unsigned char* local_text = sqlite3_column_text(stmt, 4);
+	entry.local_path = local_text ? reinterpret_cast<const char*>(local_text) : "";
 
-	entry.size_bytes = sqlite3_column_int(stmt, 3);
-	entry.downloaded = sqlite3_column_int(stmt, 4) != 0;
+	entry.downloaded = sqlite3_column_int(stmt, 5) != 0;
 
 	return entry;
 }

--- a/src/ServerInterface.hpp
+++ b/src/ServerInterface.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <sqlite3.h>
-#include <mavsdk/plugins/log_files/log_files.h>
 
 class ServerInterface
 {
@@ -23,12 +23,23 @@ public:
 		std::string message;
 	};
 
+	// A log as tracked in the database. Identity is the remote path (relative
+	// to the vehicle log root) plus the size: the path alone is not enough
+	// because ArduPilot wraps its log numbering and reuses file names.
+	struct LogEntry {
+		std::string uuid;
+		std::string remote_path;
+		std::string date;       // ISO8601 UTC, empty when the vehicle cannot report a time
+		uint32_t size_bytes {};
+	};
+
 	struct DatabaseEntry {
 		std::string uuid;
-		uint32_t id;
+		std::string remote_path;
 		std::string date;
-		uint32_t size_bytes;
-		bool downloaded;
+		uint32_t size_bytes {};
+		std::string local_path; // Empty until downloaded
+		bool downloaded {};
 	};
 
 	ServerInterface(const Settings& settings);
@@ -39,21 +50,22 @@ public:
 	void close_database();
 
 	// Log entry management
-	static std::string generate_uuid(const mavsdk::LogFiles::Entry& entry);
-	bool add_log_entry(const mavsdk::LogFiles::Entry& entry);
-	bool update_download_status(const std::string& uuid, bool downloaded);
+	static std::string generate_uuid(const std::string& remote_path, uint32_t size_bytes);
+	bool sync_log(const LogEntry& entry);
+	bool update_download_status(const std::string& uuid, const std::string& local_path, bool downloaded);
+	bool delete_log(const std::string& uuid);
 	uint32_t num_logs_to_download();
+	std::vector<DatabaseEntry> get_logs_to_download();
+	bool local_path_in_use(const std::string& local_path, const std::string& excluding_uuid);
 
 	// Upload management
 	uint32_t num_logs_to_upload();
 	DatabaseEntry get_next_log_to_upload();
-	UploadResult upload_log(const std::string& filepath);
+	UploadResult upload_log(const std::string& uuid, const std::string& filepath);
 
 	// Query methods
 	bool is_blacklisted(const std::string& uuid);
-	DatabaseEntry get_next_log_to_download();
 
-	std::string filepath_from_entry(const mavsdk::LogFiles::Entry& entry) const ;
 	std::string filepath_from_uuid(const std::string& uuid) const;
 
 	void start();
@@ -74,8 +86,18 @@ private:
 	bool add_to_blacklist(const std::string& uuid, const std::string& reason);
 	DatabaseEntry row_to_db_entry(sqlite3_stmt* stmt);
 
+	// Databases written before the MAVLink FTP transition keyed logs on the
+	// LOG_ENTRY timestamp, which FTP cannot reproduce. Their rows are moved
+	// aside on startup and matched back up by size as the FTP index comes in,
+	// so download/upload state survives the upgrade.
+	bool table_exists(const std::string& name) const;
+	bool column_exists(const std::string& table, const std::string& column) const;
+	void migrate_legacy_schema();
+	void grandfather_from_legacy(const LogEntry& entry);
+
 	Settings _settings;
 	Protocol _protocol {Protocol::Https};
 	bool _should_exit = false;
+	bool _has_legacy_table = false;
 	sqlite3* _db = nullptr;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,9 @@ int main(int argc, char** argv)
 		.mavsdk_connection_url = config["connection_url"].value_or("0.0.0"),
 		.application_directory = config["application_directory"].value_or(data_dir.string() + "/"),
 		.upload_enabled = config["upload_enabled"].value_or(false),
-		.public_logs = config["public_logs"].value_or(false)
+		.public_logs = config["public_logs"].value_or(false),
+		.remote_log_directory = config["remote_log_directory"].value_or(""),
+		.ftp_use_burst = config["ftp_use_burst"].value_or(true)
 	};
 
 	_log_loader = std::make_shared<LogLoader>(settings);


### PR DESCRIPTION
## Summary

Supersedes the transport half of #28. Replaces the classic MAVLink log protocol with MAVLink FTP for both the log listing and the bulk transfer, and adds ArduPilot support as a consequence rather than as a special case.

#28 should stay open for its other two commits — the upload-spam fix and the Flight Review API key — which are independent of the transport and good as-is (minus the 401/403 blacklisting, see the review notes on that PR).

## Problem

`LOG_DATA` (msg 120) has no `target_system`/`target_component`. A router between logloader and the autopilot has no addressing information to work with, so it copies every chunk to every endpoint it serves, telemetry radio included. On a node running mavlink-router a log download saturates links that have no interest in it.

`LOG_ENTRY` also forces a second problem: it is the only thing that identifies a log, and it reports an id and a timestamp rather than a file. Anything that downloads over FTP while listing over the log protocol has to map one onto the other by size, mtime or list ordering, and ArduPilot's list-entry numbering, its `LOG_MAX_FILES` wrap and its `.BIN` naming all have to be modelled to do it. That mapping layer is where the complexity and the failure modes live: when it guesses wrong, the wrong file is transferred in full and then discarded.

## Solution

Use MAVLink FTP for both halves. `FILE_TRANSFER_PROTOCOL` (msg 110) is addressed and both stacks reply to the requesting sysid/compid, so transfers are unicast. The log protocol is gone entirely — no `LOG_REQUEST_LIST`, no `LOG_ENTRY`, no `LOG_DATA`, no MAVSDK `LogFiles` plugin.

Identity moves to the listing: path below the log root plus size. There is no cross-protocol mapping left to get wrong, and ArduPilot needs no special handling — a directory listing just reports files. This is the shape QGC's Onboard Logs (FTP) tab already uses.

The root is probed at `@MAV_LOG` (the virtual directory from the FTP spec), then `/fs/microsd/log` and `/APM/LOGS` for older firmware. Timestamps come from the listing when the vehicle implements `ListDirectoryWithTime`, otherwise from the start time PX4 encodes in the path; ArduPilot logs have none and nothing needs one.

MAVSDK's `Ftp` plugin discards size and mtime from list replies, so `FtpListClient` runs the listing over `MavlinkPassthrough` and keeps the full entry. Bulk transfers still use the plugin. Worth upstreaming to MAVSDK later so this can be deleted.

Pre-FTP databases keyed logs on the `LOG_ENTRY` timestamp, which FTP cannot reproduce. Those rows are set aside as `logs_legacy` on first start and matched to the listing by size, so a fleet upgrading to this does not re-download and re-upload its history.

Along the way: a log is only queued once two consecutive listings agree on its size (so the log being written right now is never fetched at a size it will not keep); downloads are staged and size-checked before being moved into place; a log that cannot be fetched sorts to the back of the queue instead of blocking everything behind it; FTP sessions are reset at connect, which is what left PX4 refusing transfers until reboot after logloader was killed mid-download.

### Verified against PX4 SITL (`main`, MAVSDK 3.17.1)

- `@MAV_LOG` probe, session reset, index, burst download; files byte-identical to the vehicle's, staging directory clean afterwards.
- Timestamps via `ListDirectoryWithTime`, and via the path-derived fallback when the opcode is forced off (the path ArduPilot takes).
- `remote_log_directory` override against a physical path.
- Actively-written log correctly held back (`3 of 4 indexed, 1 still being written`) instead of being downloaded and discarded.
- Legacy migration across all three cases: downloaded+uploaded (not refetched), downloaded-not-uploaded (keeps its existing file), never-downloaded (fetched fresh).

### Follow-ups

- Bump the ARK-OS submodule pointer after this merges.
- Confirm ARK's shipped PX4 configs start the companion MAVLink instance with `-x`; FTP is now load-bearing.
- Large-file FTP timeouts that #28's hardware test hit are unaddressed here; the queue reordering keeps one bad log from blocking the rest, but resume is still worth doing.